### PR TITLE
Remove geometry_experimental from ignored file

### DIFF
--- a/rolling.ignored
+++ b/rolling.ignored
@@ -1,2 +1,1 @@
-geometry_experimental
 test_tf2


### PR DESCRIPTION
That package hasn't been present in the sources for a long time.